### PR TITLE
FFmpeg: Replace deprecated av_register_all

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -643,7 +643,7 @@ start_inotify(void)
 	if (setpriority(PRIO_PROCESS, 0, 19) == -1)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce inotify thread priority\n");
 	sqlite3_release_memory(1<<31);
-	av_register_all();
+	avformat_network_init();
 
 	while( !quitting )
 	{

--- a/monitor.c
+++ b/monitor.c
@@ -643,7 +643,6 @@ start_inotify(void)
 	if (setpriority(PRIO_PROCESS, 0, 19) == -1)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce inotify thread priority\n");
 	sqlite3_release_memory(1<<31);
-	avformat_network_init();
 
 	while( !quitting )
 	{

--- a/scanner.c
+++ b/scanner.c
@@ -901,7 +901,7 @@ start_scanner(void)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce scanner thread priority\n");
 
 	setlocale(LC_COLLATE, "");
-	av_register_all();
+	avformat_network_init();
 	av_log_set_level(AV_LOG_PANIC);
 
 	if( GETFLAG(RESCAN_MASK) )

--- a/scanner.c
+++ b/scanner.c
@@ -901,7 +901,6 @@ start_scanner(void)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce scanner thread priority\n");
 
 	setlocale(LC_COLLATE, "");
-	avformat_network_init();
 	av_log_set_level(AV_LOG_PANIC);
 
 	if( GETFLAG(RESCAN_MASK) )


### PR DESCRIPTION
with avformat_network_init function
see http://ffmpeg.org/pipermail/ffmpeg-devel/2018-February/225051.html