### PR TITLE
FFmpeg: Omitting av_register_all call

### DIFF
--- a/monitor.c
+++ b/monitor.c
@@ -643,7 +643,6 @@ start_inotify(void)
 	if (setpriority(PRIO_PROCESS, 0, 19) == -1)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce inotify thread priority\n");
 	sqlite3_release_memory(1<<31);
-	av_register_all();
 
 	while( !quitting )
 	{

--- a/scanner.c
+++ b/scanner.c
@@ -901,7 +901,6 @@ start_scanner(void)
 		DPRINTF(E_WARN, L_INOTIFY,  "Failed to reduce scanner thread priority\n");
 
 	setlocale(LC_COLLATE, "");
-	av_register_all();
 	av_log_set_level(AV_LOG_PANIC);
 
 	if( GETFLAG(RESCAN_MASK) )


### PR DESCRIPTION
- fix build errors with FFmpeg 5 due to removed deprecated functions, see http://ffmpeg.org/pipermail/ffmpeg-devel/2018-February/225051.html
- we can omit this function call in ffmpeg 4.0 and later, see https://github.com/leandromoreira/ffmpeg-libav-tutorial/issues/29#issuecomment-404939213